### PR TITLE
Added the possiblity to use dinamyc templates.

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -77,7 +77,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # If not set, the included template will be used.
   config :template, :validate => :string
 
-  # Overwrite the current template with whatever is configuredg
+  # Overwrite the current template with whatever is configured
   # in the template and template_name directives.
   config :template_overwrite, :validate => :boolean, :default => false
 
@@ -283,7 +283,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       @logger.info("Using mapping template", :template =>template_json)
       return LogStash::Json.load(template_json)
   end # def get_template
-  
+
   protected
   def start_local_elasticsearch
     @logger.info("Starting embedded Elasticsearch local node.")


### PR DESCRIPTION
 For example: 

```
elasticsearch {
                    cluster => "logstash"
                    index => "%{type}-logstash-%{+YYYY.MM.dd}"
                    template => "/etc/logstash/conf.d/%{type}-template.json"
                    template_name => "%{type}"
    }
```

It will also allow to parametrize the template. For example:

{
  "template" : "%{client_id}-*",
  "settings" : {
    "number_of_shards"            : 5,
    "index.cache.field.type"      : "soft",
    "index.refresh_interval"      : "2s",
    "index.store.compress.stored" : true,
    "index.query.default_field"   : "@message"
  },
  ......
}
